### PR TITLE
fixed python error when loading in new QGIS versions

### DIFF
--- a/RSGIS_M.py
+++ b/RSGIS_M.py
@@ -54,8 +54,7 @@ from osgeo import gdal
 import numpy as np
 import os
 from osgeo import ogr, osr
-import gdal
-from gdalconst import *
+from osgeo.gdalconst import *
 import multiprocessing
 from io import StringIO
 import tokenize


### PR DESCRIPTION
the new style import for osgeo libs required a few changes. import gdal was already done in line 53, but the gdalconst should be imported different.